### PR TITLE
docs: add gate1-c2 monthly trigger card and sync ledgers

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -153,6 +153,7 @@
   脚本：`deploy/monthly_recovery_drill.sh`
   预演证据：`design/validation/2026-03-25-monthly-recovery-drill-validation-20260325-223134.md`
   预检证据：`design/validation/2026-03-26-readiness-preflight-validation.md`
+  触发卡：`design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md`
   下次执行窗口：2026-04-25 ± 3 天（Asia/Shanghai）
   记录模板：`design/validation/monthly-recovery-drill-template.md`
   验收标准：每月至少一次演练并记录耗时、失败原因、修复动作
@@ -261,6 +262,7 @@
   条件 C1：完成 host `~/.openclaw/state/argus` 与 `~/.openclaw/workspaces/argus` apply 覆盖演练并落盘（已完成）
   C1 证据：`design/validation/2026-03-25-host-apply-drill-validation.md`
   条件 C2：形成下一次月度回归演练记录
+  C2 触发卡：`design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md`
   C2 预演证据：`design/validation/2026-03-25-monthly-recovery-drill-validation-20260325-223134.md`
   C2 预检证据：`design/validation/2026-03-26-readiness-preflight-validation.md`
   C2 模板：`design/validation/monthly-recovery-drill-template.md`

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -819,3 +819,16 @@
   - 一旦增加第二位协作者，将审批数调回 `1`
 - 证据：
   - `branches/main/protection/required_pull_request_reviews -> required_approving_review_count=0`
+
+### 2026-03-26：固化 Gate-1 C2 的“窗口触发 + 复核触发”执行卡
+
+- 决策：
+  - 将 C2（月度回归）从“口头待办”收敛为触发卡执行
+  - C2 新窗口记录落盘后，在同日或 24 小时内触发 gstack 关闭复核
+- 触发窗口（绝对日期）：
+  - 2026-04-22 至 2026-04-28（Asia/Shanghai）
+- 目的：
+  - 避免“等时间/追时间”导致的遗漏
+  - 让 C2 关闭条件与 gstack 介入时机可复用、可追溯
+- 产物：
+  - `design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md`

--- a/design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md
+++ b/design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md
@@ -1,0 +1,54 @@
+# 2026-03-26 Gate-1 条件 C2 下一窗口触发卡（v1）
+
+更新时间：2026-03-26  
+适用范围：`gstack Gate-1` 条件 C2（月度回归演练记录）  
+目标：不依赖固定会议时间，按触发条件完成 C2 收口并触发专家复核
+
+## 1) 触发窗口（绝对日期）
+
+- 执行窗口（Asia/Shanghai）：2026-04-22 至 2026-04-28（即 2026-04-25 ± 3 天）
+- 进入窗口后：优先在前 48 小时内执行，避免临近窗口末尾堆积风险
+
+## 2) 触发前最小检查
+
+1. 确认仓库 `main` 可用且运行态无阻断异常  
+2. 执行月度预检：
+
+```bash
+bash ./deploy/monthly_recovery_preflight.sh
+```
+
+3. 预检结论需为可执行（历史口径：`ready_for_monthly_window`）
+
+## 3) 窗口内执行动作
+
+执行月度一键回归：
+
+```bash
+OPENCLAW_BACKUP_PASSPHRASE_FILE="$HOME/.openclaw/secrets/backup_passphrase.txt" bash ./deploy/monthly_recovery_drill.sh
+```
+
+执行后要求：
+
+- 生成一份新的月度验证记录（`design/validation/`）
+- 生成一份新的证据归档目录（`design/validation/artifacts/`，仓库忽略）
+
+## 4) C2 关闭判定（全部满足）
+
+- 新窗口内有新的月度回归记录（非同日预演复用）
+- 记录包含：耗时、失败原因（若有）、修复动作、回切结论
+- `BACKLOG.md` / `DECISIONS.md` / `验收清单.md` 同步回填
+
+## 5) gstack 专家介入时机（事件触发）
+
+- 触发条件：C2 新窗口记录落盘且台账回填完成
+- 触发动作：在同日或 24 小时内发起一次 Gate-1 C2 关闭复核（`gstack`）
+- 复核目标：
+  - 确认 C2 关闭证据完整
+  - 确认后续月度节奏可持续（不是一次性通过）
+- 复核产物：`design/validation/<date>-gstack-gate1-c2-close-review.md`
+
+## 6) 失败与延期处理
+
+- 若窗口内执行失败：同窗口内优先补跑 1 次，并记录失败分类
+- 若窗口错过：在 `DECISIONS.md` 明确延期原因和新的绝对日期窗口，不允许口头顺延

--- a/验收清单.md
+++ b/验收清单.md
@@ -190,6 +190,8 @@
   预演证据：`design/validation/2026-03-25-monthly-recovery-drill-validation-20260325-223134.md`
   预检证据：`design/validation/2026-03-26-readiness-preflight-validation.md`
   模板：`design/validation/monthly-recovery-drill-template.md`
+- [x] 已补 C2 下一窗口触发卡（触发式）
+  触发卡：`design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md`
 - [x] 已完成 Gate-2/C2 执行前置探针
   证据：`design/validation/2026-03-26-readiness-preflight-validation.md`
 - [x] 已完成 Gate-2 插件启用与阻塞转移（`Unknown channel` -> `waiting_channel_credentials`）


### PR DESCRIPTION
## 变更摘要
- 新增 Gate-1 条件 C2 下一窗口触发卡（触发窗口、执行步骤、产物口径、失败延期处理）。
- 同步 BACKLOG / DECISIONS / 验收清单，明确 C2 关闭与 gstack 复核触发时机。

## 验证证据
- 文档新增：design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md
- 台账同步：BACKLOG.md / DECISIONS.md / 验收清单.md

## 风险与回滚
- 风险：仅文档与流程卡片更新，无运行态变更。
- 回滚：关闭 PR 或后续提交回滚文档修改。