### PR TITLE
chore: add c2 window guard to prevent off-window execution

### DIFF
--- a/deploy/c2_window_guard.sh
+++ b/deploy/c2_window_guard.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+TZ_REGION="${TZ_REGION:-Asia/Shanghai}"
+WINDOW_START="${WINDOW_START:-2026-04-22}"
+WINDOW_END="${WINDOW_END:-2026-04-28}"
+TODAY="${TODAY_OVERRIDE:-$(TZ="$TZ_REGION" date +%F)}"
+PASSPHRASE_FILE="${OPENCLAW_BACKUP_PASSPHRASE_FILE:-$HOME/.openclaw/secrets/backup_passphrase.txt}"
+
+log() {
+  printf '[c2-window-guard] %s\n' "$*"
+}
+
+log "timezone=$TZ_REGION today=$TODAY window=$WINDOW_START..$WINDOW_END"
+
+if [[ "$TODAY" < "$WINDOW_START" || "$TODAY" > "$WINDOW_END" ]]; then
+  log "outside execution window, skip monthly drill."
+  log "this is expected before 2026-04-22 or after 2026-04-28."
+  exit 2
+fi
+
+log "inside execution window, running preflight."
+bash ./deploy/monthly_recovery_preflight.sh
+
+log "running monthly recovery drill."
+OPENCLAW_BACKUP_PASSPHRASE_FILE="$PASSPHRASE_FILE" bash ./deploy/monthly_recovery_drill.sh
+
+log "completed."

--- a/design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md
+++ b/design/validation/2026-03-26-gate1-c2-next-window-trigger-card-v1.md
@@ -20,6 +20,12 @@ bash ./deploy/monthly_recovery_preflight.sh
 
 3. 预检结论需为可执行（历史口径：`ready_for_monthly_window`）
 
+可选（推荐）执行守卫脚本（自动检查窗口，窗口外拒绝执行）：
+
+```bash
+bash ./deploy/c2_window_guard.sh
+```
+
 ## 3) 窗口内执行动作
 
 执行月度一键回归：


### PR DESCRIPTION
## 变更摘要
- 新增 deploy/c2_window_guard.sh：仅在 2026-04-22~2026-04-28 窗口内执行 C2 主线脚本。
- 窗口外直接退出（code=2），防止误执行月度回归。
- 在 C2 触发卡中补充该守卫脚本的推荐用法。

## 验证证据
- 本地执行（2026-03-26）：outside execution window + exit_code=2（符合预期）
- issue #4 已留言记录：issuecomment-4131591991

## 风险与回滚
- 风险：仅新增执行守卫，无运行态配置改动。
- 回滚：移除脚本或回滚本 PR。