### PR TITLE
Gate-1 C2: 完成关闭复核并收口 #3

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -258,8 +258,8 @@
   - 四角色差异清单完成（吸收/拒绝/待验证）
   - 回归清单可执行（逐角色 + 端到端）
 
-- [ ] 关闭 gstack Gate-1 条件项（C1/C2）
-  当前状态：C1 已关闭；C2 已完成同日预演 + 预检通过 + 事件触发执行并形成新记录，待 #4 关闭后立即推进 #3 复核收口
+- [x] 关闭 gstack Gate-1 条件项（C1/C2）
+  当前状态：C1/C2 均已关闭；已完成 C2 事件触发执行、关闭复核与台账回填
   跟踪 Issue：`#3` `Gate-1 C2｜事件触发后进行 gstack 关闭复核`
   里程碑：`Gate-1 C2 closeout (event-driven)`
   条件 C1：完成 host `~/.openclaw/state/argus` 与 `~/.openclaw/workspaces/argus` apply 覆盖演练并落盘（已完成）
@@ -272,6 +272,7 @@
   C2 预检证据：`design/validation/2026-03-26-readiness-preflight-validation.md`
   C2 模板：`design/validation/monthly-recovery-drill-template.md`
   验收证据：`design/validation/2026-03-25-gstack-gate1-review.md`
+  关闭复核：`design/validation/2026-03-26-gstack-gate1-c2-close-review.md`
 
 - [x] 设立“新增/删减角色”的评审门禁（`gstack` 两段式）
   当前状态：已完成 dry-run 实战演练（申请单 + 两段评审 + 四件套草案 + 回归验证）

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -873,3 +873,16 @@
 - 同步变更：
   - `deploy/monthly_recovery_drill.sh` 结论文案改为事件触发口径
   - `deploy/monthly_recovery_preflight.sh` 摘要改为事件触发规则字段
+
+### 2026-03-26：Gate-1 条件 C2 完成关闭复核并正式收口
+
+- 复核输入：
+  - C2 执行记录：`design/validation/2026-03-26-monthly-recovery-drill-validation.md`
+  - C2 聚合证据：`design/validation/artifacts/openclaw-monthly-recovery-20260326-124457/`
+  - 关闭复核纪要：`design/validation/2026-03-26-gstack-gate1-c2-close-review.md`
+- 结论：
+  - C2 关闭复核通过（Pass）
+  - Gate-1 条件项 `C1/C2` 全部关闭
+- 收口动作：
+  - 关闭 `#3`（Gate-1 C2 关闭复核 issue）
+  - 保持“事件触发 + 月度回归 + 台账回填”作为后续运维固定口径

--- a/design/validation/2026-03-26-gstack-gate1-c2-close-review.md
+++ b/design/validation/2026-03-26-gstack-gate1-c2-close-review.md
@@ -1,0 +1,44 @@
+# 2026-03-26 Gstack Gate-1 C2 Close Review
+
+更新时间：2026-03-26  
+评审范围：`gstack Gate-1` 条件 C2（事件触发月度回归）关闭复核  
+复核触发：`#4` 已关闭 + 新记录落盘 + 三本台账已回填
+
+## 1) 输入证据
+
+- Gate-1 原评审（含条件项）：`design/validation/2026-03-25-gstack-gate1-review.md`
+- C2 事件触发卡：`design/validation/2026-03-26-gate1-c2-event-trigger-card-v2.md`
+- C2 执行记录：`design/validation/2026-03-26-monthly-recovery-drill-validation.md`
+- C2 聚合证据：`design/validation/artifacts/openclaw-monthly-recovery-20260326-124457/`
+- 执行迁移 PR：`https://github.com/Oscarling/openclaw-multi-agent/pull/8`
+- 跟踪 Issue：
+  - `#4`（已关闭）：`https://github.com/Oscarling/openclaw-multi-agent/issues/4`
+  - `#3`（本次关闭复核）：`https://github.com/Oscarling/openclaw-multi-agent/issues/3`
+
+## 2) 复核 Checklist
+
+- [x] 已核对 C2 证据完整性（记录 + 运行结果 + 台账回填）
+  - 记录包含开始/结束时间与总耗时（108 秒）
+  - 包含 recovery/host apply 两段 runId 与 postcheck 证据索引
+- [x] 已确认事件触发链路可执行
+  - `C2_TRIGGER_EVENT="mainline_ready" bash ./deploy/c2_event_guard.sh` 执行完成
+  - 预检结论为 `ready_for_monthly_window` 后自动串联月度回归
+- [x] 已确认主线口径一致
+  - `BACKLOG.md` / `DECISIONS.md` / `验收清单.md` 已统一为事件触发口径
+  - 里程碑统一为 `Gate-1 C2 closeout (event-driven)`
+
+## 3) 评审结论
+
+- 结论：**Pass（C2 可关闭）**
+- 判定：
+  - Gate-1 条件 C1：已关闭（历史结论）
+  - Gate-1 条件 C2：本次复核通过，执行关闭
+- 收口结果：
+  - Gate-1 条件项（C1/C2）全部关闭
+  - 项目进入“事件触发 + 月度回归”的常态运维阶段
+
+## 4) 后续执行口径
+
+- 继续使用事件触发命令执行月度回归：
+  - `C2_TRIGGER_EVENT="mainline_ready" bash ./deploy/c2_event_guard.sh`
+- 每次执行后同步回填三本台账，并在对应 issue 留痕，避免口头状态漂移

--- a/验收清单.md
+++ b/验收清单.md
@@ -186,13 +186,14 @@
   证据：`design/validation/2026-03-25-gstack-gate1-review.md`
 - [x] 条件 C1 已关闭：host `state/workspaces` apply 覆盖演练证据
   证据：`design/validation/2026-03-25-host-apply-drill-validation.md`
-- [ ] 待关闭条件 C2：下一次月度回归演练证据
+- [x] 条件 C2 已关闭：事件触发月度回归演练证据 + 关闭复核
   跟踪 Issue：`#4` `Gate-1 C2｜事件触发执行月度回归`
   里程碑：`Gate-1 C2 closeout (event-driven)`
   预演证据：`design/validation/2026-03-25-monthly-recovery-drill-validation-20260325-223134.md`
   本次记录：`design/validation/2026-03-26-monthly-recovery-drill-validation.md`
   预检证据：`design/validation/2026-03-26-readiness-preflight-validation.md`
   模板：`design/validation/monthly-recovery-drill-template.md`
+  关闭复核：`design/validation/2026-03-26-gstack-gate1-c2-close-review.md`
 - [x] 已补 C2 事件触发卡（触发式）
   触发卡：`design/validation/2026-03-26-gate1-c2-event-trigger-card-v2.md`
 - [x] 已补 C2 关闭复核跟踪 Issue


### PR DESCRIPTION
## 目标
完成 Gate-1 条件 C2 的关闭复核收口，结束 `#3`。

## 本次内容
- 新增关闭复核纪要：`design/validation/2026-03-26-gstack-gate1-c2-close-review.md`
- 回填并更新：`BACKLOG.md`、`DECISIONS.md`、`验收清单.md`
- 将 Gate-1 条件项状态统一为：`C1/C2 全部关闭`

## 证据链
- 执行记录：`design/validation/2026-03-26-monthly-recovery-drill-validation.md`
- 聚合证据：`design/validation/artifacts/openclaw-monthly-recovery-20260326-124457/`
- 执行迁移 PR：#8（已合并）

## 关联
Closes #3
