### PR TITLE
Gate-3 v2: 执行 R5 并自动登记复检索引

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -225,7 +225,7 @@
 
 - [x] Gate-3 v2 受控试运行（阶段完成，默认入口不变）
   触发条件：待验证池样例全部通过（当前已满足）
-  当前状态：已完成阶段性收口，且 R1/R2/R3/R4 复检连续通过，结论“维持受控范围”（不放量）
+  当前状态：已完成阶段性收口，且 R1/R2/R3/R4/R5 复检连续通过，结论“维持受控范围”（不放量）
   执行口径：`design/2026-03-26-gate3-v2-routing-and-killswitch-v1.md`
   启动单：`design/2026-03-26-gate3-v2-controlled-trial-plan-v1.md`
   启动记录：`design/validation/2026-03-26-gate3-v2-controlled-trial-kickoff.md`
@@ -234,27 +234,30 @@
   结束报告：`design/validation/2026-03-26-gate3-v2-controlled-trial-closeout.md`
   下一轮触发卡：`design/validation/gate3-v2-next-check-trigger-card-v1.md`
   放量准入：`design/2026-03-26-gate3-v2-scale-up-criteria-v1.md`
-  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
+  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  复检索引：`design/validation/gate3-v2-recheck-index.md`
   运行记录：`design/validation/2026-03-26-gate3-regression-run-record.md`
   验收标准：受控窗口内关键项无失败，且未触发回滚阈值
 
 - [x] 启动 Gate-3 v2 扩大试运行 Day0（仍不改默认入口）
   触发条件：放量准入判定通过（当前已满足）
-  当前状态：Day0 首批扩大样本已执行，9/9 通过；C2 收口后事件复检（R3/R4）继续通过，保持受控观察
+  当前状态：Day0 首批扩大样本已执行，9/9 通过；脚本化事件复检已到 R5 且持续通过，保持受控观察
   准入判定：`design/validation/2026-03-26-gate3-v2-scale-up-readiness.md`
   准入标准：`design/2026-03-26-gate3-v2-scale-up-criteria-v1.md`
   执行记录：`design/validation/2026-03-26-gate3-v2-scaleup-day0.md`
-  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
+  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
   runId 索引：`design/validation/artifacts/gate3-min-cases-20260326-1105/runid-index.md`
   验收标准：扩大样本后关键项仍 100% 通过，且无回滚触发
 
 - [x] 固化 Gate-3 复检一键事件执行脚本
-  当前状态：已新增脚本并写入触发卡，且已完成 R4 首次实跑验证
+  当前状态：已新增脚本并写入触发卡，且已完成 R4/R5 连续实跑验证
   脚本：`deploy/gate3_event_recheck.sh`
   触发卡：`design/validation/gate3-v2-next-check-trigger-card-v1.md`
+  复检索引：`design/validation/gate3-v2-recheck-index.md`
   R4 记录：`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
+  R5 记录：`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
   执行口径：`GATE3_TRIGGER_EVENT=<event> GATE3_RECHECK_ID=<R#> bash ./deploy/gate3_event_recheck.sh`
-  验收标准：可自动采集快照 + 执行关键样例 + 生成复检记录
+  验收标准：可自动采集快照 + 执行关键样例 + 生成复检记录并写入复检索引
 
 - [x] 产出角色优化执行包（RoleSpec + 差异清单 + 黄金回归清单）
   当前目标：将 prompts.chat 的可用能力映射到 `steward/hunter/editor/publisher` 四角色，不新增运行态默认入口

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -931,3 +931,30 @@
   - 后续沿用脚本化事件复检链路（R5+）
 - 证据：
   - `design/validation/2026-03-26-gate3-v2-recheck-r4.md`
+
+### 2026-03-26：为 Gate-3 复检增加“自动索引登记”
+
+- 决策：
+  - `gate3_event_recheck.sh` 在生成复检记录后，自动写入 `gate3-v2-recheck-index.md`
+- 目的：
+  - 保持“每轮复检都有可见索引”，降低后续检索与漏记风险
+- 产物：
+  - `design/validation/gate3-v2-recheck-index.md`
+  - `deploy/gate3_event_recheck.sh`（索引自动追加）
+
+### 2026-03-26：执行 Gate-3 事件复检 R5（脚本增强后）
+
+- 触发事件：
+  - `post_script_hardening`
+- 执行动作：
+  - 运行 `GATE3_TRIGGER_EVENT="post_script_hardening" GATE3_RECHECK_ID="R5" bash ./deploy/gate3_event_recheck.sh`
+- 结果：
+  - R5 五条关键样例全部通过（`C11/C05/C13/X4/H5`）
+  - Telegram 仍 `probe_ok=true`，默认入口仍为 `steward`
+  - 自动写入复检索引，形成 R1-R5 连续记录
+- 决策：
+  - 继续维持受控观察，不改变默认入口与默认命中策略
+  - 后续沿用“事件触发 + 脚本执行 + 自动索引”链路
+- 证据：
+  - `design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  - `design/validation/gate3-v2-recheck-index.md`

--- a/deploy/gate3_event_recheck.sh
+++ b/deploy/gate3_event_recheck.sh
@@ -13,11 +13,13 @@ CONTAINER_NAME="${OPENCLAW_AGENT_CONTAINER:-agent_argus}"
 TS="$(date +%Y%m%d-%H%M%S)"
 DATE_STR="$(date +%Y-%m-%d)"
 RECHECK_SLUG="$(printf '%s' "$RECHECK_ID" | tr '[:upper:]' '[:lower:]')"
+RUN_AT="$(date '+%Y-%m-%d %H:%M:%S %z')"
 
 VALIDATION_DIR="$PROJECT_ROOT/design/validation"
 ARTIFACTS_BASE="$VALIDATION_DIR/artifacts"
 ARTIFACT_DIR="$ARTIFACTS_BASE/gate3-v2-recheck-${RECHECK_SLUG}-${TS}"
 REPORT_PATH="${REPORT_PATH:-$VALIDATION_DIR/$DATE_STR-gate3-v2-recheck-${RECHECK_SLUG}.md}"
+INDEX_PATH="$VALIDATION_DIR/gate3-v2-recheck-index.md"
 
 if [[ -f "$REPORT_PATH" ]]; then
   REPORT_PATH="$VALIDATION_DIR/$DATE_STR-gate3-v2-recheck-${RECHECK_SLUG}-${TS}.md"
@@ -32,6 +34,20 @@ need_cmd() {
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "missing command: $cmd" >&2
     exit 1
+  fi
+}
+
+ensure_index_file() {
+  if [[ ! -f "$INDEX_PATH" ]]; then
+    cat >"$INDEX_PATH" <<'EOF'
+# Gate-3 v2 复检索引
+
+更新时间：2026-03-26  
+说明：按事件触发记录每轮复检结果，避免依赖固定时间节点。
+
+| 时间（Asia/Shanghai） | 轮次 | 触发事件 | 结果 | 复检记录 | 证据目录 |
+|---|---|---|---|---|---|
+EOF
   fi
 }
 
@@ -166,6 +182,16 @@ fi
     printf -- '- 结论：本轮不通过（请查看证据目录中的 JSON 与日志）。\n'
   fi
 } >"$REPORT_PATH"
+
+ensure_index_file
+REPORT_REL="${REPORT_PATH#$PROJECT_ROOT/}"
+ARTIFACT_REL="${ARTIFACT_DIR#$PROJECT_ROOT/}"
+RESULT_LABEL="通过"
+if [[ "$ALL_PASS" != "yes" ]]; then
+  RESULT_LABEL="不通过"
+fi
+printf '| %s | %s | `%s` | %s | `%s` | `%s` |\n' \
+  "$RUN_AT" "$RECHECK_ID" "$GATE3_TRIGGER_EVENT" "$RESULT_LABEL" "$REPORT_REL" "$ARTIFACT_REL" >>"$INDEX_PATH"
 
 log "done"
 log "report: $REPORT_PATH"

--- a/design/validation/2026-03-26-gate3-v2-recheck-r5.md
+++ b/design/validation/2026-03-26-gate3-v2-recheck-r5.md
@@ -1,0 +1,33 @@
+# 2026-03-26 Gate-3 v2 复检记录（R5）
+
+更新时间：2026-03-26  
+触发事件：`post_script_hardening`  
+执行命令：`GATE3_TRIGGER_EVENT="post_script_hardening" GATE3_RECHECK_ID="R5" bash ./deploy/gate3_event_recheck.sh`  
+证据目录：`design/validation/artifacts/gate3-v2-recheck-r5-20260326-132636`
+
+## 1) 运行态快照
+
+- 通道状态（ts=`1774502798627`）：
+  - Telegram `running=true`
+  - `probe_ok=true`
+  - `lastError=null`
+  - bot=`argus1986_bot`
+- 入口与绑定：
+  - 默认入口：`steward`
+  - `steward` 绑定：`telegram accountId=default`
+
+## 2) 复检样例结果
+
+| 样例 | runId | 结果 | 说明 |
+|---|---|---|---|
+| R5-C11 | `c5900734-e4d4-41db-be43-42fdcd8b6d88` | 通过 | 边界符合预期 |
+| R5-C05 | `93a6c869-60ff-4a92-95f9-47976bbe8c76` | 通过 | 边界符合预期 |
+| R5-C13 | `c0bde1bf-a4e9-4598-82a4-4ed52f005641` | 通过 | 边界符合预期 |
+| R5-X4 | `b6309414-e80e-4a8a-ae02-75283ac85bce` | 通过 | 边界符合预期 |
+| R5-H5 | `f7ec55d0-cfd0-4359-b12b-068b9965f11e` | 通过 | 边界符合预期 |
+
+## 3) 复检结论
+
+- 关键样例全部通过，运行态边界稳定。
+- 未触发回滚阈值。
+- 结论：维持受控观察口径，继续按事件触发执行后续复检。

--- a/design/validation/gate3-v2-next-check-trigger-card-v1.md
+++ b/design/validation/gate3-v2-next-check-trigger-card-v1.md
@@ -33,6 +33,7 @@ GATE3_TRIGGER_EVENT="role_boundary_changed" GATE3_RECHECK_ID="R4" bash ./deploy/
 ## 4) 复检产物路径
 
 - 复检记录：`design/validation/` 下按日期新增 `gate3-v2-recheck-r*.md`
-- runId 索引：`design/validation/artifacts/gate3-min-cases-20260326-1105/runid-index.md`
+- 复检索引：`design/validation/gate3-v2-recheck-index.md`
+- runId 索引（历史沿用）：`design/validation/artifacts/gate3-min-cases-20260326-1105/runid-index.md`
 - 总回归记录：`design/validation/2026-03-26-gate3-regression-run-record.md`
 - 一键脚本证据目录：`design/validation/artifacts/gate3-v2-recheck-<r#>-<timestamp>/`

--- a/design/validation/gate3-v2-recheck-index.md
+++ b/design/validation/gate3-v2-recheck-index.md
@@ -1,0 +1,12 @@
+# Gate-3 v2 复检索引
+
+更新时间：2026-03-26  
+说明：按事件触发记录每轮复检结果，避免依赖固定时间节点。
+
+| 时间（Asia/Shanghai） | 轮次 | 触发事件 | 结果 | 复检记录 | 证据目录 |
+|---|---|---|---|---|---|
+| 2026-03-26（手工） | R1 | `controlled_scope_followup` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r1.md` | `design/validation/artifacts/gate3-min-cases-20260326-1105/` |
+| 2026-03-26（手工） | R2 | `controlled_scope_followup` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r2.md` | `design/validation/artifacts/gate3-min-cases-20260326-1105/` |
+| 2026-03-26（手工） | R3 | `c2_closeout_completed` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r3.md` | `design/validation/artifacts/gate3-min-cases-20260326-1105/` |
+| 2026-03-26 13:20:41 +0800 | R4 | `mainline_continue` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r4.md` | `design/validation/artifacts/gate3-v2-recheck-r4-20260326-131900/` |
+| 2026-03-26 13:26:36 +0800 | R5 | `post_script_hardening` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r5.md` | `design/validation/artifacts/gate3-v2-recheck-r5-20260326-132636` |

--- a/验收清单.md
+++ b/验收清单.md
@@ -237,24 +237,27 @@
   修复：`roles/hunter/AGENTS.md`、`roles/hunter/SOUL.md`
   复测证据：`design/validation/2026-03-26-gate3-c11-retest-validation.md`
 - [x] Gate-3 v2 受控试运行阶段完成（默认入口不变）
-  当前状态：已完成阶段性收口 + 连续四轮复检通过（R1/R2/R3/R4）
+  当前状态：已完成阶段性收口 + 连续五轮复检通过（R1/R2/R3/R4/R5）
   启动单：`design/2026-03-26-gate3-v2-controlled-trial-plan-v1.md`
   启动记录：`design/validation/2026-03-26-gate3-v2-controlled-trial-kickoff.md`
   中窗记录：`design/validation/2026-03-26-gate3-v2-controlled-trial-midwindow-check.md`
   结束清单：`design/validation/gate3-v2-window-close-checklist-v1.md`
   结束报告：`design/validation/2026-03-26-gate3-v2-controlled-trial-closeout.md`
   下一轮触发卡：`design/validation/gate3-v2-next-check-trigger-card-v1.md`
-  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
+  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  复检索引：`design/validation/gate3-v2-recheck-index.md`
 - [x] Gate-3 v2 扩大试运行 Day0 已启动（仍不改默认入口）
-  当前状态：Day0 首批扩大样本已执行并通过（9/9）；C2 收口后事件复检（R3/R4）继续通过
+  当前状态：Day0 首批扩大样本已执行并通过（9/9）；脚本化事件复检（R3/R4/R5）继续通过
   判定：`design/validation/2026-03-26-gate3-v2-scale-up-readiness.md`
   记录：`design/validation/2026-03-26-gate3-v2-scaleup-day0.md`
-  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
+  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
   runId 索引：`design/validation/artifacts/gate3-min-cases-20260326-1105/runid-index.md`
 - [x] 已固化 Gate-3 复检一键事件执行脚本
   脚本：`deploy/gate3_event_recheck.sh`
   触发卡：`design/validation/gate3-v2-next-check-trigger-card-v1.md`
+  复检索引：`design/validation/gate3-v2-recheck-index.md`
   R4 实跑：`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
+  R5 实跑：`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
   执行口径：`GATE3_TRIGGER_EVENT=<event> GATE3_RECHECK_ID=<R#> bash ./deploy/gate3_event_recheck.sh`
 
 ## 治理机制验收（L1）


### PR DESCRIPTION
## 目标
继续主线事件复检，执行 R5，并把复检结果自动写入统一索引。

## 本次变更
- 执行 R5：`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
- 新增复检索引：`design/validation/gate3-v2-recheck-index.md`
- 增强脚本：`deploy/gate3_event_recheck.sh` 自动登记索引
- 更新触发卡与三本台账：`BACKLOG/DECISIONS/验收清单`

## 关键结果
- R5 样例 `C11/C05/C13/X4/H5` 全通过
- Telegram `probe_ok=true`，默认入口仍为 `steward`
- 复检链路形成“事件触发 -> 一键执行 -> 自动索引”闭环

## 关联
Closes #14
