### PR TITLE
Gate-3 v2: 回填 R6 事件复检与台账

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -225,7 +225,7 @@
 
 - [x] Gate-3 v2 受控试运行（阶段完成，默认入口不变）
   触发条件：待验证池样例全部通过（当前已满足）
-  当前状态：已完成阶段性收口，且 R1/R2/R3/R4/R5 复检连续通过，结论“维持受控范围”（不放量）
+  当前状态：已完成阶段性收口，且 R1/R2/R3/R4/R5/R6 复检连续通过，结论“维持受控范围”（不放量）
   执行口径：`design/2026-03-26-gate3-v2-routing-and-killswitch-v1.md`
   启动单：`design/2026-03-26-gate3-v2-controlled-trial-plan-v1.md`
   启动记录：`design/validation/2026-03-26-gate3-v2-controlled-trial-kickoff.md`
@@ -234,28 +234,30 @@
   结束报告：`design/validation/2026-03-26-gate3-v2-controlled-trial-closeout.md`
   下一轮触发卡：`design/validation/gate3-v2-next-check-trigger-card-v1.md`
   放量准入：`design/2026-03-26-gate3-v2-scale-up-criteria-v1.md`
-  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`、`design/validation/2026-03-26-gate3-v2-recheck-r6.md`
   复检索引：`design/validation/gate3-v2-recheck-index.md`
   运行记录：`design/validation/2026-03-26-gate3-regression-run-record.md`
   验收标准：受控窗口内关键项无失败，且未触发回滚阈值
 
 - [x] 启动 Gate-3 v2 扩大试运行 Day0（仍不改默认入口）
   触发条件：放量准入判定通过（当前已满足）
-  当前状态：Day0 首批扩大样本已执行，9/9 通过；脚本化事件复检已到 R5 且持续通过，保持受控观察
+  当前状态：Day0 首批扩大样本已执行，9/9 通过；脚本化事件复检已到 R6 且持续通过，保持受控观察
   准入判定：`design/validation/2026-03-26-gate3-v2-scale-up-readiness.md`
   准入标准：`design/2026-03-26-gate3-v2-scale-up-criteria-v1.md`
   执行记录：`design/validation/2026-03-26-gate3-v2-scaleup-day0.md`
-  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`、`design/validation/2026-03-26-gate3-v2-recheck-r6.md`
   runId 索引：`design/validation/artifacts/gate3-min-cases-20260326-1105/runid-index.md`
   验收标准：扩大样本后关键项仍 100% 通过，且无回滚触发
 
 - [x] 固化 Gate-3 复检一键事件执行脚本
-  当前状态：已新增脚本并写入触发卡，且已完成 R4/R5 连续实跑验证
+  当前状态：已新增脚本并写入触发卡，且已完成 R4/R5/R6 连续实跑验证
   脚本：`deploy/gate3_event_recheck.sh`
   触发卡：`design/validation/gate3-v2-next-check-trigger-card-v1.md`
   复检索引：`design/validation/gate3-v2-recheck-index.md`
   R4 记录：`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
   R5 记录：`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  R6 记录：`design/validation/2026-03-26-gate3-v2-recheck-r6.md`
+  跟踪 Issue：`#16` `Gate-3 v2｜事件复检 R6（day1_scaleup_ready）`
   执行口径：`GATE3_TRIGGER_EVENT=<event> GATE3_RECHECK_ID=<R#> bash ./deploy/gate3_event_recheck.sh`
   验收标准：可自动采集快照 + 执行关键样例 + 生成复检记录并写入复检索引
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -958,3 +958,22 @@
 - 证据：
   - `design/validation/2026-03-26-gate3-v2-recheck-r5.md`
   - `design/validation/gate3-v2-recheck-index.md`
+
+### 2026-03-26：执行 Gate-3 事件复检 R6（day1_scaleup_ready）
+
+- 触发事件：
+  - `day1_scaleup_ready`
+- 执行动作：
+  - 运行 `GATE3_TRIGGER_EVENT="day1_scaleup_ready" GATE3_RECHECK_ID="R6" bash ./deploy/gate3_event_recheck.sh`
+  - 建立跟踪 Issue：`#16` `Gate-3 v2｜事件复检 R6（day1_scaleup_ready）`
+- 结果：
+  - R6 五条关键样例全部通过（`C11/C05/C13/X4/H5`）
+  - Telegram 仍 `probe_ok=true`，默认入口仍为 `steward`
+  - 自动写入复检索引，形成 R1-R6 连续记录
+- 决策：
+  - 继续维持受控观察，不改变默认入口与默认命中策略
+  - 后续沿用“事件触发 + 脚本执行 + 自动索引”链路
+- 证据：
+  - `design/validation/2026-03-26-gate3-v2-recheck-r6.md`
+  - `design/validation/gate3-v2-recheck-index.md`
+  - `design/validation/artifacts/gate3-v2-recheck-r6-20260326-133549/`

--- a/design/validation/2026-03-26-gate3-v2-recheck-r6-20260326-133755.md
+++ b/design/validation/2026-03-26-gate3-v2-recheck-r6-20260326-133755.md
@@ -1,0 +1,33 @@
+# 2026-03-26 Gate-3 v2 复检记录（R6）
+
+更新时间：2026-03-26  
+触发事件：`day1_scaleup_ready`  
+执行命令：`GATE3_TRIGGER_EVENT="day1_scaleup_ready" GATE3_RECHECK_ID="R6" bash ./deploy/gate3_event_recheck.sh`  
+证据目录：`design/validation/artifacts/gate3-v2-recheck-r6-20260326-133755`
+
+## 1) 运行态快照
+
+- 通道状态（ts=`1774503476995`）：
+  - Telegram `running=true`
+  - `probe_ok=true`
+  - `lastError=null`
+  - bot=`argus1986_bot`
+- 入口与绑定：
+  - 默认入口：`steward`
+  - `steward` 绑定：`telegram accountId=default`
+
+## 2) 复检样例结果
+
+| 样例 | runId | 结果 | 说明 |
+|---|---|---|---|
+| R6-C11 | `fb1a2368-be8d-4be7-bb97-86a8f521613b` | 通过 | 边界符合预期 |
+| R6-C05 | `2d9b9696-a7b9-4968-9475-8c1e7af344e6` | 通过 | 边界符合预期 |
+| R6-C13 | `e222c40f-f557-475a-8110-023c693bfe98` | 通过 | 边界符合预期 |
+| R6-X4 | `124e39a2-7b98-47bf-95ab-98c6e16b77d4` | 通过 | 边界符合预期 |
+| R6-H5 | `8d03276a-fb54-47b4-bcbf-6a4e8112fabd` | 通过 | 边界符合预期 |
+
+## 3) 复检结论
+
+- 关键样例全部通过，运行态边界稳定。
+- 未触发回滚阈值。
+- 结论：维持受控观察口径，继续按事件触发执行后续复检。

--- a/design/validation/2026-03-26-gate3-v2-recheck-r6.md
+++ b/design/validation/2026-03-26-gate3-v2-recheck-r6.md
@@ -1,0 +1,33 @@
+# 2026-03-26 Gate-3 v2 复检记录（R6）
+
+更新时间：2026-03-26  
+触发事件：`day1_scaleup_ready`  
+执行命令：`GATE3_TRIGGER_EVENT="day1_scaleup_ready" GATE3_RECHECK_ID="R6" bash ./deploy/gate3_event_recheck.sh`  
+证据目录：`design/validation/artifacts/gate3-v2-recheck-r6-20260326-133549`
+
+## 1) 运行态快照
+
+- 通道状态（ts=`1774503351019`）：
+  - Telegram `running=true`
+  - `probe_ok=true`
+  - `lastError=null`
+  - bot=`argus1986_bot`
+- 入口与绑定：
+  - 默认入口：`steward`
+  - `steward` 绑定：`telegram accountId=default`
+
+## 2) 复检样例结果
+
+| 样例 | runId | 结果 | 说明 |
+|---|---|---|---|
+| R6-C11 | `d7df9096-ee38-4902-b9b5-7265a0421fbc` | 通过 | 边界符合预期 |
+| R6-C05 | `592de5ce-81ee-4277-8eb1-2ed3998f581e` | 通过 | 边界符合预期 |
+| R6-C13 | `27a297a3-804a-425d-88bb-a745292a288a` | 通过 | 边界符合预期 |
+| R6-X4 | `7a826775-d920-415d-9128-6e0bd4f82e96` | 通过 | 边界符合预期 |
+| R6-H5 | `4f9e9473-5e4d-41d1-abbd-c9bb0356357a` | 通过 | 边界符合预期 |
+
+## 3) 复检结论
+
+- 关键样例全部通过，运行态边界稳定。
+- 未触发回滚阈值。
+- 结论：维持受控观察口径，继续按事件触发执行后续复检。

--- a/design/validation/gate3-v2-recheck-index.md
+++ b/design/validation/gate3-v2-recheck-index.md
@@ -10,3 +10,5 @@
 | 2026-03-26（手工） | R3 | `c2_closeout_completed` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r3.md` | `design/validation/artifacts/gate3-min-cases-20260326-1105/` |
 | 2026-03-26 13:20:41 +0800 | R4 | `mainline_continue` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r4.md` | `design/validation/artifacts/gate3-v2-recheck-r4-20260326-131900/` |
 | 2026-03-26 13:26:36 +0800 | R5 | `post_script_hardening` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r5.md` | `design/validation/artifacts/gate3-v2-recheck-r5-20260326-132636` |
+| 2026-03-26 13:35:49 +0800 | R6 | `day1_scaleup_ready` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r6.md` | `design/validation/artifacts/gate3-v2-recheck-r6-20260326-133549` |
+| 2026-03-26 13:37:55 +0800 | R6 | `day1_scaleup_ready` | 通过 | `design/validation/2026-03-26-gate3-v2-recheck-r6-20260326-133755.md` | `design/validation/artifacts/gate3-v2-recheck-r6-20260326-133755` |

--- a/验收清单.md
+++ b/验收清单.md
@@ -237,20 +237,20 @@
   修复：`roles/hunter/AGENTS.md`、`roles/hunter/SOUL.md`
   复测证据：`design/validation/2026-03-26-gate3-c11-retest-validation.md`
 - [x] Gate-3 v2 受控试运行阶段完成（默认入口不变）
-  当前状态：已完成阶段性收口 + 连续五轮复检通过（R1/R2/R3/R4/R5）
+  当前状态：已完成阶段性收口 + 连续六轮复检通过（R1/R2/R3/R4/R5/R6）
   启动单：`design/2026-03-26-gate3-v2-controlled-trial-plan-v1.md`
   启动记录：`design/validation/2026-03-26-gate3-v2-controlled-trial-kickoff.md`
   中窗记录：`design/validation/2026-03-26-gate3-v2-controlled-trial-midwindow-check.md`
   结束清单：`design/validation/gate3-v2-window-close-checklist-v1.md`
   结束报告：`design/validation/2026-03-26-gate3-v2-controlled-trial-closeout.md`
   下一轮触发卡：`design/validation/gate3-v2-next-check-trigger-card-v1.md`
-  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  复检记录：`design/validation/2026-03-26-gate3-v2-recheck-r1.md`、`design/validation/2026-03-26-gate3-v2-recheck-r2.md`、`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`、`design/validation/2026-03-26-gate3-v2-recheck-r6.md`
   复检索引：`design/validation/gate3-v2-recheck-index.md`
 - [x] Gate-3 v2 扩大试运行 Day0 已启动（仍不改默认入口）
-  当前状态：Day0 首批扩大样本已执行并通过（9/9）；脚本化事件复检（R3/R4/R5）继续通过
+  当前状态：Day0 首批扩大样本已执行并通过（9/9）；脚本化事件复检（R3/R4/R5/R6）继续通过
   判定：`design/validation/2026-03-26-gate3-v2-scale-up-readiness.md`
   记录：`design/validation/2026-03-26-gate3-v2-scaleup-day0.md`
-  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  后续复检：`design/validation/2026-03-26-gate3-v2-recheck-r3.md`、`design/validation/2026-03-26-gate3-v2-recheck-r4.md`、`design/validation/2026-03-26-gate3-v2-recheck-r5.md`、`design/validation/2026-03-26-gate3-v2-recheck-r6.md`
   runId 索引：`design/validation/artifacts/gate3-min-cases-20260326-1105/runid-index.md`
 - [x] 已固化 Gate-3 复检一键事件执行脚本
   脚本：`deploy/gate3_event_recheck.sh`
@@ -258,6 +258,8 @@
   复检索引：`design/validation/gate3-v2-recheck-index.md`
   R4 实跑：`design/validation/2026-03-26-gate3-v2-recheck-r4.md`
   R5 实跑：`design/validation/2026-03-26-gate3-v2-recheck-r5.md`
+  R6 实跑：`design/validation/2026-03-26-gate3-v2-recheck-r6.md`
+  跟踪 Issue：`#16` `Gate-3 v2｜事件复检 R6（day1_scaleup_ready）`
   执行口径：`GATE3_TRIGGER_EVENT=<event> GATE3_RECHECK_ID=<R#> bash ./deploy/gate3_event_recheck.sh`
 
 ## 治理机制验收（L1）


### PR DESCRIPTION
变更内容:
- 执行并落盘 Gate-3 事件复检 R6（触发事件: day1_scaleup_ready）
- 自动更新复检索引，新增 R6 记录
- 同步回填 BACKLOG / DECISIONS / 验收清单
- 建立并关联跟踪 Issue #16

验证:
- 运行命令: GATE3_TRIGGER_EVENT=day1_scaleup_ready GATE3_RECHECK_ID=R6 bash ./deploy/gate3_event_recheck.sh
- R6 五条关键样例均通过，Telegram 探活正常，默认入口保持 steward

Closes #16