### PR TITLE
docs: close A53 stable-run close review with two-stage minutes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1015,8 +1015,11 @@
   复核验证：`design/validation/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-round1-validation.md`
   当前状态：`parallel_mainline_multi_account_trial_window_stable_run_round1_passed`，`next_event=parallel_mainline_multi_account_trial_window_stable_run_round1_completed`
 
-- [ ] 发起并行主链多账号自动登录受控窗口稳定态运行阶段收口评审（A53）
+- [x] 发起并行主链多账号自动登录受控窗口稳定态运行阶段收口评审（A53）
   触发条件：A52 完成且 `next_event=parallel_mainline_multi_account_trial_window_stable_run_round1_completed`
   完成标准：形成稳定态运行阶段收口结论与“继续试运行/阶段收口完成”入口建议，并回填三本账
   执行动作：组织两段式评审（`office-hours -> plan-eng-review`）确认稳定态运行是否进入阶段收口
   输入包：`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-prep-v1.md`
+  预评审纪要：`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-office-hours-minutes-v1.md`
+  正式评审纪要：`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-plan-eng-review-minutes-v1.md`
+  当前状态：结论 `Go（稳定态运行阶段收口完成，进入常态受控运营）`，`next_event=parallel_mainline_multi_account_trial_window_stable_run_stage_closeout_completed`

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -3801,3 +3801,26 @@
   - `design/validation/artifacts/openclaw-parallel-mainline-stable-run-round1-account2-20260329-144919/artifacts/summary.txt`
 - 决策：
   - 采纳 A52，下一执行点转入 A53：稳定态运行阶段收口评审
+
+### 2026-03-29：完成并行主链多账号自动登录受控窗口稳定态运行阶段收口评审（A53）
+
+- 背景：
+  - A52 已完成稳定态运行首轮持续复核，主线进入阶段收口评审。
+  - 目标是给出“继续试运行/阶段收口完成/停机”中的唯一结论。
+- 执行动作：
+  - 产出收口评审输入包：
+    - `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-prep-v1.md`
+  - 完成两段式评审：
+    - `office-hours`：`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-office-hours-minutes-v1.md`
+    - `plan-eng-review`：`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-plan-eng-review-minutes-v1.md`
+- 结果：
+  - 预评审结论：`Conditional-Go`
+  - 正式评审结论：`Go（稳定态运行阶段收口完成，进入常态受控运营）`
+  - 约束口径：维持双账号受控范围，不扩容、不改阈值，继续事件驱动与审计回填
+  - 下一事件：`parallel_mainline_multi_account_trial_window_stable_run_stage_closeout_completed`
+- 证据：
+  - `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-prep-v1.md`
+  - `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-office-hours-minutes-v1.md`
+  - `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-plan-eng-review-minutes-v1.md`
+- 决策：
+  - 采纳 A53，主线阶段收口完成；后续保持常态受控运营并继续 `RH-T5-B01` 侧线事件驱动治理

--- a/design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-office-hours-minutes-v1.md
+++ b/design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-office-hours-minutes-v1.md
@@ -1,0 +1,34 @@
+# 2026-03-29 并行主链多账号自动登录受控窗口稳定态运行阶段收口预评审纪要（office-hours，A53，v1）
+
+scope: `parallel_mainline_multi_account_trial_window_stable_run_close_review_prereview`  
+日期：2026-03-29  
+触发事件：`parallel_mainline_multi_account_trial_window_stable_run_close_review_requested`  
+边界：本结论仅用于阶段收口预评审，不替代正式工程收口结论。
+
+## 1) 输入材料
+
+1. `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-prep-v1.md`
+2. `design/validation/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-round1-validation.md`
+3. `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-entry-confirm-plan-eng-review-minutes-v1.md`
+
+## 2) 预评审结论
+
+结论：**Conditional-Go**
+
+判定依据：
+
+1. A52 双账号持续复核通过，具备阶段收口正式评审前提。
+2. 仍需在正式评审中明确“阶段收口完成但不扩容”的硬边界。
+3. 建议进入 `plan-eng-review` 输出最终唯一结论。
+
+## 3) 风险边界
+
+1. 保持双账号受控范围，不新增账号与平台。
+2. 保持 Stage C 阈值、停机规则与审计回填纪律不变。
+3. 保持 `RH-T5-B01` 侧线跟踪开启，不因主线收口而关单。
+
+## 4) 下一事件
+
+`parallel_mainline_multi_account_trial_window_stable_run_close_plan_review_requested`
+
+STATUS: `DONE_WITH_CONCERNS`

--- a/design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-plan-eng-review-minutes-v1.md
+++ b/design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-plan-eng-review-minutes-v1.md
@@ -1,0 +1,44 @@
+# 2026-03-29 并行主链多账号自动登录受控窗口稳定态运行阶段收口正式工程评审纪要（plan-eng-review，A53，v1）
+
+scope: `parallel_mainline_multi_account_trial_window_stable_run_close_plan_review`  
+日期：2026-03-29  
+触发事件：`parallel_mainline_multi_account_trial_window_stable_run_close_plan_review_requested`  
+决策边界：仅判定“稳定态运行阶段是否收口完成并进入常态受控运营”。
+
+## 1) 输入材料
+
+1. `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-prep-v1.md`
+2. `design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-office-hours-minutes-v1.md`
+3. `design/validation/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-round1-validation.md`
+
+## 2) 正式结论
+
+结论：**Go（稳定态运行阶段收口完成，进入常态受控运营）**
+
+判定依据：
+
+1. A50/A51/A52 连续链路在受控边界内稳定通过，关键证据可追溯。
+2. 双账号 Stage A/B/C 指标满足继续条件，未触发停机门禁。
+3. 运行入口、值守规则、审计纪律已固化，具备阶段收口条件。
+
+## 3) 放行边界
+
+允许：
+
+1. A53 标记完成，并将主线状态切换为“阶段收口完成”。
+2. 按既有常态受控规则继续运营，不改变阈值与护栏。
+3. 保持 issue #37 与 `RH-T5-B01` 侧线事件驱动跟踪。
+
+禁止：
+
+1. 未评审扩容账号、放宽阈值或绕过停机规则。
+2. 未评审修改安全 wrapper 与审计回填纪律。
+3. 将“主线阶段收口完成”误读为“可忽略 RH-T5-B01 侧线阻断”。
+
+## 4) 下一事件
+
+`parallel_mainline_multi_account_trial_window_stable_run_stage_closeout_completed`
+
+next_event: `parallel_mainline_multi_account_trial_window_stable_run_stage_closeout_completed`
+
+STATUS: `DONE`

--- a/验收清单.md
+++ b/验收清单.md
@@ -740,9 +740,11 @@
   结论：已通过，`parallel_mainline_multi_account_trial_window_stable_run_round1_passed`（判定：`Continue`）
   证据：`design/validation/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-round1-validation.md`
 
-- [ ] 已发起并行主链多账号自动登录受控窗口稳定态运行阶段收口评审（A53）
+- [x] 已发起并行主链多账号自动登录受控窗口稳定态运行阶段收口评审（A53）
   触发条件：A52 结论发布
   完成标准：形成稳定态运行阶段收口结论与后续入口建议（事件驱动）
+  结论：已通过，`office-hours=Conditional-Go`，`plan-eng-review=Go（稳定态运行阶段收口完成，进入常态受控运营）`
+  证据：`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-prep-v1.md`、`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-office-hours-minutes-v1.md`、`design/2026-03-29-parallel-mainline-multi-account-trial-window-stable-run-close-review-plan-eng-review-minutes-v1.md`
 
 ## 角色变更门禁验收（Dry-Run）
 


### PR DESCRIPTION
## Summary
- add A53 two-stage review minutes (office-hours + plan-eng-review)
- close A53 in BACKLOG and 验收清单
- append A53 final decision and next event in DECISIONS

## Validation
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

## Result
- office-hours=Conditional-Go
- plan-eng-review=Go（稳定态运行阶段收口完成，进入常态受控运营）
- next_event=parallel_mainline_multi_account_trial_window_stable_run_stage_closeout_completed